### PR TITLE
Add a shortcut for checking uniformArray when both of vertex and pixe…

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/Renderer11.cpp
@@ -2481,6 +2481,11 @@ gl::Error Renderer11::applyUniforms(const ProgramD3D &programD3D,
 
     for (const D3DUniform *uniform : uniformArray)
     {
+        if (totalRegisterCountVS && totalRegisterCountPS &&
+            vertexUniformsDirty && pixelUniformsDirty) {
+          break;
+        }
+
         if (uniform->isReferencedByVertexShader() && !uniform->isSampler())
         {
             totalRegisterCountVS += uniform->registerCount;


### PR DESCRIPTION
I notice we can add this shortcut to skip the following redundant check inside the loop of uniformArray, and it should bring some performance benefit for us.