### PR TITLE
Fix multiple_draw_buffers sample

### DIFF
--- a/samples/multiple_draw_buffers/MultipleDrawBuffers.cpp
+++ b/samples/multiple_draw_buffers/MultipleDrawBuffers.cpp
@@ -56,7 +56,7 @@ class MultipleDrawBuffersSample : public SampleApplication
         fsStream << angle::GetExecutableDirectory() << "/multiple_draw_buffers_fs.glsl";
 
         std::stringstream copyFsStream;
-        fsStream << angle::GetExecutableDirectory() << "/multiple_draw_buffers_copy_fs.glsl";
+        copyFsStream << angle::GetExecutableDirectory() << "/multiple_draw_buffers_copy_fs.glsl";
 
         mMRTProgram = CompileProgramFromFiles(vsStream.str(), fsStream.str());
         if (!mMRTProgram)


### PR DESCRIPTION
Due to misprint the sample tries to load a shader with invalid path.