### PR TITLE
fix a freeze when returning from fullscreen to maximized @nvidia

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
+++ b/src/libANGLE/renderer/d3d/d3d9/SwapChain9.cpp
@@ -355,7 +355,7 @@ EGLint SwapChain9::swapRect(const gl::Context *context,
     // On Windows 8 systems, IDirect3DSwapChain9::Present sometimes returns 0x88760873 when the windows is
     // in the process of entering/exiting fullscreen. This code doesn't seem to have any documentation.  The
     // device appears to be ok after emitting this error so simply return a failure to swap.
-    if (result == static_cast<HRESULT>(0x88760873))
+    if (result == static_cast<HRESULT>(0x88760873) || result == static_cast<HRESULT>(0x88760872))
     {
         return EGL_BAD_MATCH;
     }


### PR DESCRIPTION
proceeding to 'if (FAILED(result))' block freezes my application. happens at least on windows 7, 8.1 and 10