### PR TITLE
Fixed a bug in the D3D11 backend where glSamplerParameteri(..., GL_TEXTURE_MIN_FILTER, ...) was not respected to determine if there are mipmaps

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,3 +53,4 @@ Andrei Volykhin
 Jérôme Duval
 Руслан Ижбулатов
 Thomas Miller
+Till Rathmann

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -101,6 +101,7 @@ Sebastian Bergstein
 James Ross-Gowan
 Andrei Volykhin
 Jérôme Duval
+Till Rathmann
 
 Microsoft Corporation
  Cooper Partin

--- a/src/libANGLE/renderer/d3d/d3d11/StateManager11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/StateManager11.cpp
@@ -2392,7 +2392,7 @@ angle::Result StateManager11::applyTextures(const gl::Context *context, gl::Shad
                 samplerObject ? samplerObject->getSamplerState() : texture->getSamplerState();
 
             ANGLE_TRY(setSamplerState(context, shaderType, samplerIndex, texture, samplerState));
-            ANGLE_TRY(setTexture(context, shaderType, samplerIndex, texture));
+            ANGLE_TRY(setTexture(context, shaderType, samplerIndex, texture, samplerState));
         }
         else
         {
@@ -2405,7 +2405,8 @@ angle::Result StateManager11::applyTextures(const gl::Context *context, gl::Shad
             ANGLE_TRY(mRenderer->getIncompleteTexture(context, textureType, &incompleteTexture));
             ANGLE_TRY(setSamplerState(context, shaderType, samplerIndex, incompleteTexture,
                                       incompleteTexture->getSamplerState()));
-            ANGLE_TRY(setTexture(context, shaderType, samplerIndex, incompleteTexture));
+            ANGLE_TRY(setTexture(context, shaderType, samplerIndex, incompleteTexture,
+                                 incompleteTexture->getSamplerState()));
         }
     }
 
@@ -2491,7 +2492,8 @@ angle::Result StateManager11::setSamplerState(const gl::Context *context,
 angle::Result StateManager11::setTexture(const gl::Context *context,
                                          gl::ShaderType type,
                                          int index,
-                                         gl::Texture *texture)
+                                         gl::Texture *texture,
+                                         const gl::SamplerState &sampler)
 {
     ASSERT(type != gl::ShaderType::Compute);
     const d3d11::SharedSRV *textureSRV = nullptr;
@@ -2508,7 +2510,7 @@ angle::Result StateManager11::setTexture(const gl::Context *context,
 
         TextureStorage11 *storage11 = GetAs<TextureStorage11>(texStorage);
 
-        ANGLE_TRY(storage11->getSRVForSampler(context, texture->getTextureState(), &textureSRV));
+        ANGLE_TRY(storage11->getSRVForSampler(context, texture->getTextureState(), sampler, &textureSRV));
 
         // If we get an invalid SRV here, something went wrong in the texture class and we're
         // unexpectedly missing the shader resource view.

--- a/src/libANGLE/renderer/d3d/d3d11/StateManager11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/StateManager11.h
@@ -300,7 +300,8 @@ class StateManager11 final : angle::NonCopyable
     angle::Result setTexture(const gl::Context *context,
                              gl::ShaderType type,
                              int index,
-                             gl::Texture *texture);
+                             gl::Texture *texture,
+                             const gl::SamplerState &sampler);
     angle::Result setTextureForImage(const gl::Context *context,
                                      gl::ShaderType type,
                                      int index,

--- a/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/TextureStorage11.h
@@ -95,6 +95,7 @@ class TextureStorage11 : public TextureStorage
 
     virtual angle::Result getSRVForSampler(const gl::Context *context,
                                            const gl::TextureState &textureState,
+                                           const gl::SamplerState &sampler,
                                            const d3d11::SharedSRV **outSRV);
     angle::Result getSRVForImage(const gl::Context *context,
                                  const gl::ImageUnit &imageUnit,
@@ -393,6 +394,7 @@ class TextureStorage11_EGLImage final : public TextureStorage11
                               const TextureHelper11 **outResource) override;
     angle::Result getSRVForSampler(const gl::Context *context,
                                    const gl::TextureState &textureState,
+                                   const gl::SamplerState &sampler,
                                    const d3d11::SharedSRV **outSRV) override;
     angle::Result getMippedResource(const gl::Context *context,
                                     const TextureHelper11 **outResource) override;

--- a/src/tests/gl_tests/TextureTest.cpp
+++ b/src/tests/gl_tests/TextureTest.cpp
@@ -1594,11 +1594,7 @@ TEST_P(Texture2DTest, TextureNPOT_GL_ALPHA_UBYTE)
     glGenTextures(1, &tex2D);
     glBindTexture(GL_TEXTURE_2D, tex2D);
 
-    std::vector<GLubyte> pixels(1 * npotTexSize * npotTexSize);
-    for (size_t pixelId = 0; pixelId < npotTexSize * npotTexSize; ++pixelId)
-    {
-        pixels[pixelId] = 64;
-    }
+    const std::vector<GLubyte> pixels(1 * npotTexSize * npotTexSize, 64);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -3754,7 +3750,7 @@ TEST_P(Texture2DTestES3, GenerateMipmapAndBaseLevelLUMA)
     EXPECT_PIXEL_COLOR_EQ(0, 0, angle::GLColor::white);
 }
 
-// Covers a bug in the D3D11 backend:
+// Covers a bug in the D3D11 backend (see https://github.com/google/angle/pull/23):
 // When using a sampler the texture was created as if it has mipmaps, regardless what you
 // specified in GL_TEXTURE_MIN_FILTER via glSamplerParameteri() --
 // mistakenly the default value GL_NEAREST_MIPMAP_LINEAR or the value set by
@@ -3795,7 +3791,7 @@ TEST_P(Texture2DTestES3, MinificationWithSamplerNoMipmapping)
 
     const GLsizei texWidth = getWindowWidth();
     const GLsizei texHeight = getWindowHeight();
-    std::vector<GLColor> whiteData(texWidth * texHeight, GLColor::white);
+    const std::vector<GLColor> whiteData(texWidth * texHeight, GLColor::white);
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texWidth, texHeight, 0, GL_RGBA,
         GL_UNSIGNED_BYTE, whiteData.data());

--- a/src/tests/gl_tests/TextureTest.cpp
+++ b/src/tests/gl_tests/TextureTest.cpp
@@ -3754,6 +3754,57 @@ TEST_P(Texture2DTestES3, GenerateMipmapAndBaseLevelLUMA)
     EXPECT_PIXEL_COLOR_EQ(0, 0, angle::GLColor::white);
 }
 
+// Covers a bug in the D3D11 backend:
+// When using a sampler the texture was created as if it has mipmaps, regardless what you
+// specified in GL_TEXTURE_MIN_FILTER via glSamplerParameteri() --
+// mistakenly the default value GL_NEAREST_MIPMAP_LINEAR or the value set by
+// glTexParameteri(..., GL_TEXTURE_MIN_FILTER, ...) was evaluated.
+// If you didn't provide mipmaps and didn't let the driver generate them this led to not
+// sampling your texture data when minification happened.
+TEST_P(Texture2DTestES3, MinificationWithSamplerNoMipmapping)
+{
+    const std::string vs =
+        "#version 300 es\n"
+        "out vec2 texcoord;\n"
+        "in vec4 position;\n"
+        "void main()\n"
+        "{\n"
+        "    gl_Position = vec4(position.xy * 0.1, 0.0, 1.0);\n"
+        "    texcoord = (position.xy * 0.5) + 0.5;\n"
+        "}\n";
+
+    const std::string fs =
+        "#version 300 es\n"
+        "precision highp float;\n"
+        "uniform highp sampler2D tex;\n"
+        "in vec2 texcoord;\n"
+        "out vec4 fragColor;\n"
+        "void main()\n"
+        "{\n"
+        "    fragColor = texture(tex, texcoord);\n"
+        "}\n";
+    ANGLE_GL_PROGRAM(program, vs, fs);
+
+    GLSampler sampler;
+    glBindSampler(0, sampler);
+    glSamplerParameteri(sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glSamplerParameteri(sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, mTexture2D);
+
+    const GLsizei texWidth = getWindowWidth();
+    const GLsizei texHeight = getWindowHeight();
+    std::vector<GLColor> whiteData(texWidth * texHeight, GLColor::white);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texWidth, texHeight, 0, GL_RGBA,
+        GL_UNSIGNED_BYTE, whiteData.data());
+    EXPECT_GL_NO_ERROR();
+
+    drawQuad(program, "position", 0.5f);
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2, getWindowHeight() / 2, angle::GLColor::white);
+}
+
 // Use this to select which configurations (e.g. which renderer, which GLES major version) these
 // tests should be run against.
 ANGLE_INSTANTIATE_TEST(Texture2DTest,


### PR DESCRIPTION
When using a sampler the texture was created as if it has mipmaps, regardless what you specified in GL_TEXTURE_MIN_FILTER via glSamplerParameteri() -- mistakenly the default value GL_NEAREST_MIPMAP_LINEAR or the value set by glTexParameteri(..., GL_TEXTURE_MIN_FILTER, ...) was evaluated.
If you didn't provide mipmaps and didn't let the driver generate them this led to not sampling your texture data when minification happened.

Ticket: https://bugs.chromium.org/p/angleproject/issues/detail?id=2772