### PR TITLE
Remove a useless test (reported by cppcheck)

### DIFF
--- a/src/libANGLE/validationES.cpp
+++ b/src/libANGLE/validationES.cpp
@@ -3065,7 +3065,7 @@ bool ValidateGetUniformBase(Context *context, GLuint program, GLint location)
         return false;
     }
 
-    if (!programObject || !programObject->isLinked())
+    if (!programObject->isLinked())
     {
         context->validationError(GL_INVALID_OPERATION, kProgramNotLinked);
         return false;


### PR DESCRIPTION
This file is part of the Firefox code base.
cppcheck reports:
   ../hg_firefox/gfx/angle/checkout/src/libANGLE/validationES.cpp
   3031	identicalConditionAfterEarlyExit	398	warning	Identical condition '!programObject', second condition is always false

So axe the duplicated test. This is also more consistent with the 'if (!programObject->isValidUniformLocation(location))' test just a few line below.