### PR TITLE
Fixed a typo to avoid an error in vertex - pixel shaders linkage.

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/shaders/Passthrough2D11.hlsl
+++ b/src/libANGLE/renderer/d3d/d3d11/shaders/Passthrough2D11.hlsl
@@ -27,7 +27,7 @@ float4 PS_PassthroughA2D(in float4 inPosition : SV_POSITION, in float2 inTexCoor
     return float4(0.0f, 0.0f, 0.0f, TextureF.Sample(Sampler, inTexCoord).a);
 }
 
-float4 PS_PassthroughRGBA2DMS(in float4 inPosition : SV_POSITION, in float2 inTexCoord : TEXCORD0, in uint inSampleIndex : SV_SAMPLEINDEX) : SV_TARGET0
+float4 PS_PassthroughRGBA2DMS(in float4 inPosition : SV_POSITION, in float2 inTexCoord : TEXCOORD0, in uint inSampleIndex : SV_SAMPLEINDEX) : SV_TARGET0
 {
     return TextureF_MS.sample[inSampleIndex][inTexCoord].rgba;
 }


### PR DESCRIPTION
I fixed a typo from TEXCORD to TEXCOORD to avoid an error:
D3D11 ERROR: ID3D11DeviceContext::Draw: Vertex Shader - Pixel Shader linkage error: Signatures between stages are incompatible. The input stage requires Semantic/Index (TEXCORD,0) as input, but it is not provided by the output stage. [ EXECUTION ERROR #342: DEVICE_SHADER_LINKAGE_SEMANTICNAME_NOT_FOUND]