### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/DevSetup.md
+++ b/doc/DevSetup.md
@@ -76,6 +76,19 @@ ninja -C out/Release
 Ninja automatically calls GN to regenerate the build files on any configuration change.
 Ensure `depot_tools` is in your path as it provides ninja.
 
+### Installing and building via vcpkg
+
+You can download and install angle using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+vcpkg install angle
+    ```
+The angle port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Building with Visual Studio
 
 To generate the Visual Studio solution in `out/Debug/angle-debug.sln`:


### PR DESCRIPTION
`angle `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg/), a C++ library manager that simplifies installation for `angle `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `angle`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/tree/master/ports/angle). We try to keep the library maintained as close as possible to the original library.