### PR TITLE
Properly construct C++ std strings

### DIFF
--- a/src/gpu_info_util/SystemInfo_macos.mm
+++ b/src/gpu_info_util/SystemInfo_macos.mm
@@ -47,7 +47,7 @@ std::string GetMachineModel()
 
     if (platformExpert == IO_OBJECT_NULL)
     {
-        return "";
+        return {};
     }
 
     CFDataRef modelData = static_cast<CFDataRef>(
@@ -55,10 +55,10 @@ std::string GetMachineModel()
     if (modelData == nullptr)
     {
         IOObjectRelease(platformExpert);
-        return "";
+        return {};
     }
 
-    std::string result = reinterpret_cast<const char *>(CFDataGetBytePtr(modelData));
+    std::string result(reinterpret_cast<const char *>(CFDataGetBytePtr(modelData)));
 
     IOObjectRelease(platformExpert);
     CFRelease(modelData);

--- a/src/libANGLE/renderer/metal/mtl_common.mm
+++ b/src/libANGLE/renderer/metal/mtl_common.mm
@@ -96,7 +96,7 @@ std::string FormatMetalErrorMessage(NSError *error)
 {
     if (!error)
     {
-        return "";
+        return {};
     }
 
     std::stringstream errorStream;

--- a/src/libANGLE/renderer/metal/mtl_utils.mm
+++ b/src/libANGLE/renderer/metal/mtl_utils.mm
@@ -52,7 +52,7 @@ ANGLE_APPLE_UNUSED
 std::string GetMetalCaptureFile()
 {
 #if !ANGLE_METAL_FRAME_CAPTURE_ENABLED
-    return "";
+    return {};
 #else
     auto var                   = std::getenv("ANGLE_METAL_FRAME_CAPTURE_FILE");
     const std::string filePath = var ? var : "";


### PR DESCRIPTION
"" is an empty C string in Objective-C++, and we need to use the constructor to turn a C string into std::string.