### PR TITLE
Update DisplayMtl.mm

### DIFF
--- a/src/libANGLE/renderer/metal/DisplayMtl.mm
+++ b/src/libANGLE/renderer/metal/DisplayMtl.mm
@@ -488,7 +488,10 @@ void DisplayMtl::generateExtensions(egl::DisplayExtensions *outExtensions) const
     outExtensions->mtlSyncSharedEventANGLE = true;
 }
 
-void DisplayMtl::generateCaps(egl::Caps *outCaps) const {}
+void DisplayMtl::generateCaps(egl::Caps *outCaps) const 
+{
+    outCaps->textureNPOT = true; 
+}
 
 void DisplayMtl::populateFeatureList(angle::FeatureList *features)
 {


### PR DESCRIPTION
DisplayMtl::generateCaps does not fill in the outCaps data, resulting in random values when using caps.textureNPOT in validationEGL.cpp.