### PR TITLE
Fix gcc13 compilation error

### DIFF
--- a/include/GLSLANG/ShaderVars.h
+++ b/include/GLSLANG/ShaderVars.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 namespace sh
 {


### PR DESCRIPTION
`/home/vliumonica/angle/buildtrees/angle/src/fb17168c17-081a7ef021.clean/include/GLSLANG/ShaderVars.h:127:70: error: ‘uint32_t’ has not been declared`
Add the header file corresponding to uint32_t.
Usage test pass with following triplets:
`x64-linux`