### PR TITLE
Fix integer overflow in getArraySizeProduct() / ArraySizeProduct() / InnerArraySizeProduct()

### DIFF
--- a/src/common/utilities.cpp
+++ b/src/common/utilities.cpp
@@ -16,6 +16,7 @@
 #include "common/platform.h"
 #include "common/string_utils.h"
 
+#include <limits>
 #include <set>
 
 #if defined(ANGLE_ENABLE_WINDOWS_UWP)
@@ -976,9 +977,15 @@ bool SamplerNameContainsNonZeroArrayElement(const std::string &name)
 
 unsigned int ArraySizeProduct(const std::vector<unsigned int> &arraySizes)
 {
+    // Saturate on overflow; a wrapped (small) product defeats downstream size/limit checks.
     unsigned int arraySizeProduct = 1u;
     for (unsigned int arraySize : arraySizes)
     {
+        if (arraySize != 0u &&
+            arraySizeProduct > std::numeric_limits<unsigned int>::max() / arraySize)
+        {
+            return std::numeric_limits<unsigned int>::max();
+        }
         arraySizeProduct *= arraySize;
     }
     return arraySizeProduct;
@@ -986,10 +993,17 @@ unsigned int ArraySizeProduct(const std::vector<unsigned int> &arraySizes)
 
 unsigned int InnerArraySizeProduct(const std::vector<unsigned int> &arraySizes)
 {
+    // Saturate on overflow; a wrapped (small) product defeats downstream size/limit checks.
     unsigned int arraySizeProduct = 1u;
     for (size_t index = 0; index + 1 < arraySizes.size(); ++index)
     {
-        arraySizeProduct *= arraySizes[index];
+        const unsigned int arraySize = arraySizes[index];
+        if (arraySize != 0u &&
+            arraySizeProduct > std::numeric_limits<unsigned int>::max() / arraySize)
+        {
+            return std::numeric_limits<unsigned int>::max();
+        }
+        arraySizeProduct *= arraySize;
     }
     return arraySizeProduct;
 }

--- a/src/compiler/translator/Types.cpp
+++ b/src/compiler/translator/Types.cpp
@@ -559,10 +559,20 @@ int TType::getLocationCount() const
 
 unsigned int TType::getArraySizeProduct() const
 {
+    // Saturate on overflow instead of silently wrapping.  A wrapped (small) product would
+    // defeat downstream size/limit checks that treat this value as the element count of the
+    // type (e.g. CalculateVariableSize() feeding TParseContext::checkVariableSize(), and the
+    // packing limit in VariablePacker), leading to under-sized allocations / out-of-bounds
+    // access for attacker-controlled array dimensions such as float x[65536][65536].
+    // Mirrors the saturating behavior already used by getObjectSize()/getLocationCount().
     unsigned int product = 1u;
 
     for (unsigned int arraySize : mArraySizes)
     {
+        if (arraySize != 0u && product > std::numeric_limits<unsigned int>::max() / arraySize)
+        {
+            return std::numeric_limits<unsigned int>::max();
+        }
         product *= arraySize;
     }
     return product;


### PR DESCRIPTION
## Summary

`TType::getArraySizeProduct()` (`src/compiler/translator/Types.cpp:560`),
`gl::ArraySizeProduct()` and `gl::InnerArraySizeProduct()`
(`src/common/utilities.cpp:977/987`) multiply per-dimension sizes as plain
`unsigned int` with no overflow handling. A shader declaring
`float x[65536][65536]` produces a product of `2^32 ≡ 0`, which collapses
`CalculateVariableSize()` to zero and silently passes
`TParseContext::checkVariableSize()` — the guard (`ParseContext.cpp:1767`)
that exists specifically to prevent driver-side integer-size overflows in
WebGL contexts (`rejectWebglShadersWithLargeVariables = true`).

The same wrapped value bypasses the register-packing limit in
`VariablePacker.cpp:220` and feeds buffer/loop-count calculations in the
D3D, Metal and HLSL back-ends (~30 call sites, e.g.
`ProgramExecutableD3D.cpp:1476`).

This is a variant of the class hardened in `TIntermAggregate::getConstantValue()`
(`IntermNode.cpp:879`, `CheckedNumeric … ValueOrDie()`,
`crbug.com/498400132`) — that fix covered the constant-folding allocation
path but missed these type-level product functions that feed the oversize guard.

## Fix

Saturate the product to `UINT_MAX` on overflow in all three functions,
matching the existing behaviour of `getObjectSize()` and `getLocationCount()`
on the same type.

## Minimal reproduction

```glsl
#version 310 es
precision highp float;
float big[65536][65536]; // product 2^32 → wraps to 0
out vec4 col;
void main() { big[0][0] = 1.0; col = vec4(big[0][0]); }
```

```js
const gl = canvas.getContext('webgl2');
const s = gl.createShader(gl.FRAGMENT_SHADER);
gl.shaderSource(s, src);
gl.compileShader(s);
// shader compiles without error; oversize-variable guard does not fire
```

Verified: `getArraySizeProduct({65536u, 65536u})` returns `0`; after fix returns `UINT_MAX`.